### PR TITLE
feat: do not store invalid headers in manifest

### DIFF
--- a/main.php
+++ b/main.php
@@ -21,6 +21,16 @@ if (!file_exists($configFile)) {
     exit(2);
 }
 
+function fillHeader($header)
+{
+    array_walk($header, function (&$value, $index) {
+        if (!$value) {
+            $value = "col_" . ($index + 1);
+        }
+    });
+    return $header;
+}
+
 try {
     $jsonDecode = new JsonDecode(true);
     $jsonEncode = new \Symfony\Component\Serializer\Encoder\JsonEncode();
@@ -84,11 +94,9 @@ try {
             }
             $csv = new Keboola\Csv\CsvFile($detectFile, $manifest["delimiter"], $manifest["enclosure"]);
             if ($parameters["columns_from"] === 'auto') {
-                $manifest["columns"] = array_map(function($index) {
-                    return "col_{$index}";
-                }, range(1, $csv->getColumnsCount(), 1));
+                $manifest["columns"] = fillHeader(array_fill(0, $csv->getColumnsCount(), ""));
             } elseif ($parameters["columns_from"] === 'header') {
-                $manifest["columns"] = $csv->getHeader();
+                $manifest["columns"] = fillHeader($csv->getHeader());
             }
         }
 

--- a/tests/invalid-columns/expected/data/out/tables/data.csv
+++ b/tests/invalid-columns/expected/data/out/tables/data.csv
@@ -1,0 +1,3 @@
+"this","","csv"
+"another",1,line
+"above is empty line"

--- a/tests/invalid-columns/expected/data/out/tables/data.csv.manifest
+++ b/tests/invalid-columns/expected/data/out/tables/data.csv.manifest
@@ -1,0 +1,1 @@
+{"delimiter":",","enclosure":"\"","primary_key":[],"incremental":false,"columns":["this","col_2","csv"]}

--- a/tests/invalid-columns/source/data/config.json
+++ b/tests/invalid-columns/source/data/config.json
@@ -1,0 +1,5 @@
+{
+	"parameters": {
+		"columns_from": "header"
+	}
+}

--- a/tests/invalid-columns/source/data/in/tables/data.csv
+++ b/tests/invalid-columns/source/data/in/tables/data.csv
@@ -1,0 +1,3 @@
+"this","","csv"
+"another",1,line
+"above is empty line"


### PR DESCRIPTION
cons: file and manifest columns is no longer in sync, this should not be a problem in the present usecase however (followed by skiplines)