### PR TITLE
Update keboola/csv to v3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,15 +4,15 @@
     "license": "MIT",
     "type": "project",
     "require": {
+        "ext-mbstring": "*",
+        "PHP": "^7.1",
+        "keboola/csv": "^3.0.0",
         "keboola/php-component": "^4.1",
-        "keboola/csv": "^1.1",
+        "symfony/config": "^4.0",
         "symfony/filesystem": "^4.0",
         "symfony/finder": "^4.0",
-        "PHP": "^7.1",
         "symfony/process": "^4.0",
-        "symfony/serializer": "^4.0",
-        "symfony/config": "^4.0",
-        "ext-mbstring": "*"
+        "symfony/serializer": "^4.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,29 +4,31 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7f43e8693a269652bf0bfbd827869617",
+    "content-hash": "574dc89e52ede3685b8864f99edf914a",
     "packages": [
         {
             "name": "keboola/csv",
-            "version": "1.4.2",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/keboola/php-csv.git",
-                "reference": "eb77f51e22d3e13a8e14a5d5a0b588cf9e8c56c5"
+                "reference": "ffb01ab98a2dd367fda3ebcf21d1f3df84709ff3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/keboola/php-csv/zipball/eb77f51e22d3e13a8e14a5d5a0b588cf9e8c56c5",
-                "reference": "eb77f51e22d3e13a8e14a5d5a0b588cf9e8c56c5",
+                "url": "https://api.github.com/repos/keboola/php-csv/zipball/ffb01ab98a2dd367fda3ebcf21d1f3df84709ff3",
+                "reference": "ffb01ab98a2dd367fda3ebcf21d1f3df84709ff3",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.6"
+                "php": ">=7.4"
             },
             "require-dev": {
-                "codeclimate/php-test-reporter": "^0.4",
-                "phpunit/phpunit": "^5.7",
-                "squizlabs/php_codesniffer": "^3.2"
+                "ext-json": "*",
+                "keboola/coding-standard": "^13.0",
+                "php-parallel-lint/php-parallel-lint": "^1.3",
+                "phpstan/phpstan": "^1.4",
+                "phpunit/phpunit": ">=7.5"
             },
             "type": "library",
             "autoload": {
@@ -50,7 +52,11 @@
                 "csv",
                 "rfc4180"
             ],
-            "time": "2018-05-14T07:45:45+00:00"
+            "support": {
+                "issues": "https://github.com/keboola/php-csv/issues",
+                "source": "https://github.com/keboola/php-csv/tree/3.0.0"
+            },
+            "time": "2022-05-10T11:00:31+00:00"
         },
         {
             "name": "keboola/php-component",
@@ -2296,8 +2302,9 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^7.1",
-        "ext-mbstring": "*"
+        "ext-mbstring": "*",
+        "php": "^7.1"
     },
-    "platform-dev": []
+    "platform-dev": [],
+    "plugin-api-version": "2.3.0"
 }

--- a/src/Component.php
+++ b/src/Component.php
@@ -6,7 +6,7 @@ namespace Keboola\Processor\CreateManifest;
 
 use Keboola\Component\BaseComponent;
 use Keboola\Component\UserException;
-use Keboola\Csv\CsvFile;
+use Keboola\Csv\CsvReader;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Process\Process;
 use Symfony\Component\Serializer\Encoder\JsonEncoder;
@@ -78,7 +78,7 @@ class Component extends BaseComponent
                         }
 
                         if ($parameters["columns_from"] === 'header') {
-                            $csv = new CsvFile(
+                            $csv = new CsvReader(
                                 $detectFile,
                                 $manifest["delimiter"],
                                 $manifest["enclosure"]
@@ -87,7 +87,7 @@ class Component extends BaseComponent
 
                             // ensure all slices have same headers
                             foreach ($subFinder as $slicedFilePart) {
-                                $csv = new CsvFile(
+                                $csv = new CsvReader(
                                     $slicedFilePart->getPathname(),
                                     $manifest["delimiter"],
                                     $manifest["enclosure"]
@@ -106,7 +106,7 @@ class Component extends BaseComponent
                             }
                         }
                     }
-                    $csv = new CsvFile($detectFile, $manifest["delimiter"], $manifest["enclosure"]);
+                    $csv = new CsvReader($detectFile, $manifest["delimiter"], $manifest["enclosure"]);
                     if ($parameters["columns_from"] === 'auto') {
                         $manifest["columns"] = $this->fillHeader(array_fill(0, $csv->getColumnsCount(), ""));
                     } elseif ($parameters["columns_from"] === 'header') {


### PR DESCRIPTION
Changes:

- Update keboola/csv to v3

---

We need to update keboola/csv to 2.3 or 3.0 (I updated to v3) to get rid of BOM, which was added in v2.3:
- https://github.com/keboola/php-csv/releases/tag/2.3.0

I updated to new classes.